### PR TITLE
Fix incompatibility with MacOSX12.sdk version of vecLib.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ One solution is to force GNU Fortran to adopt the older, F2C-style return
 value convention, using the ``-ff2c`` flag. If that solution is sufficient
 for you, then I encourage you to adopt it. Unfortunately, this may not be
 possible if there is other code or other libraries that you rely upon that
-assume the default GNU Fotran convention. And don't forget to rewrite your
+assume the default GNU Fortran convention. And don't forget to rewrite your
 C code according to the F2C return value conventions.
 
 The approach taken by vecLibFort is to provide a thin translation layer

--- a/vecLib-760.100.h
+++ b/vecLib-760.100.h
@@ -1,0 +1,68 @@
+/*
+ * Modeled from Apple's vecLib-760.10 instance of vecLib.h:
+ * /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers/vecLib.h
+ */
+
+#ifndef __VECLIB__
+#define __VECLIB__
+
+#ifndef __VECLIBTYPES__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vecLibTypes.h>
+#endif
+
+#ifndef __VBASICOPS__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vBasicOps.h>
+#endif
+
+#ifndef __VBIGNUM__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vBigNum.h>
+#endif
+
+#ifndef __VECTOROPS__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vectorOps.h>
+#endif
+
+#ifndef __VFP__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vfp.h>
+#endif
+
+#ifndef __VDSP__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vDSP.h>
+#endif
+
+#if defined __ppc__ || defined __i386__
+#ifndef __VDSP_TRANSLATE__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vDSP_translate.h>
+#endif
+#endif
+
+#ifndef CBLAS_H	
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/cblas.h>
+#endif
+
+#ifndef __CLAPACK_H
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/clapack.h>
+#endif
+
+#ifndef __LINEAR_ALGEBRA_PUBLIC_HEADER__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/LinearAlgebra/LinearAlgebra.h>
+#endif
+
+#ifndef __SPARSE_HEADER__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/Sparse/Sparse.h>
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/Sparse/Solve.h>
+#endif
+
+#ifndef __QUADRATURE_PUBLIC_HEADER__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/Quadrature/Quadrature.h>
+#endif // __QUADRATURE_PUBLIC_HEADER__
+
+#ifndef __BNNS_HEADER__
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/BNNS/bnns.h>
+#endif // __BNNS_HEADER__
+
+#ifndef __VFORCE_H
+#include <Accelerate/../Frameworks/vecLib.framework/Headers/vForce.h>
+#endif
+
+#endif /* __VECLIB__ */

--- a/vecLibFort.c
+++ b/vecLibFort.c
@@ -19,6 +19,7 @@
 /* Don't load the CLAPACK header, because we are using a different calling
    convention for the replaced functions than the ones listed there. */
 #define __CLAPACK_H
+#include "vecLib-760.100.h"
 #include <Accelerate/Accelerate.h>
 #include <AvailabilityMacros.h>
 


### PR DESCRIPTION
Incorporate local copy of version 760.100 of vecLib.h that doesn't contain the include of fortran_blas.h present in version 794.40 of vecLib.h.