### PR TITLE
vecLibFort.c: Fix build on OS X 10.9 and earlier

### DIFF
--- a/vecLibFort.c
+++ b/vecLibFort.c
@@ -19,9 +19,11 @@
 /* Don't load the CLAPACK header, because we are using a different calling
    convention for the replaced functions than the ones listed there. */
 #define __CLAPACK_H
-#include "vecLib-760.100.h"
-#include <Accelerate/Accelerate.h>
 #include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
+#include "vecLib-760.100.h"
+#endif
+#include <Accelerate/Accelerate.h>
 
 /* Add a SGEMV fix for Mavericks. See
   http://www.openradar.me/radar?id=5864367807528960 */


### PR DESCRIPTION
Only include the local macOS 11 SDK copy of vecLib.h when using the macOS 12 SDK or later to prevent build failure when using the OS X 10.9 SDK or older.

Fixes #14