### PR TITLE
Makefile: Do not require -O optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(DYNAMIC): $(OBJECT)
 		-install_name $(LIBDIR)/$@
 
 $(PRELOAD): $(SOURCE) $(DEPEND)
-	clang -shared $(CFLAGS) -DVECLIBFORT_INTERPOSE -o $@ -O $(SOURCE) \
+	clang -shared $(CFLAGS) -DVECLIBFORT_INTERPOSE -o $@ $(SOURCE) \
 		-Wl,-reexport_framework -Wl,Accelerate \
 		-install_name $(LIBDIR)/$@
 


### PR DESCRIPTION
`-O` is already specified in the default CFLAGS. Do not override other optimization flags the user might have specified in CFLAGS.